### PR TITLE
fix: support use of  based URLs

### DIFF
--- a/drupal8.conf
+++ b/drupal8.conf
@@ -221,7 +221,7 @@ server {
         rewrite ^ $upload_form_uri?X-Progress-ID=$upload_id;
     }
 
-    location ^~ /progress {
+    location ~ ^/progress$ {
         upload_progress_json_output;
         report_uploads uploads;
     }


### PR DESCRIPTION
Noticed urls starting with `progress` were failing due to this configuration. It'd be nice to use URLs that may start with the word `progress` like `progressively-enhanced-website` for example without it being matched to this `progress` keyword. 
