### PR TITLE
Added svgz support to drupal7/8.conf

### DIFF
--- a/drupal7.conf
+++ b/drupal7.conf
@@ -48,7 +48,7 @@ server {
             open_file_cache_min_uses 2;
             open_file_cache_errors off;
         }
-    
+
         location ^~ /sites/.*/files/advagg_css/ {
             expires max;
             add_header ETag '';
@@ -75,7 +75,7 @@ server {
             try_files $uri @drupal;
         }
 
-        location ~* ^.+\.(?:css|cur|js|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff|woff2|svg)$ {
+        location ~* ^.+\.(?:css|cur|js|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff2?|svgz?)$ {
             access_log off;
             expires 30d;
             tcp_nodelay off;
@@ -83,6 +83,11 @@ server {
             open_file_cache_valid 45s;
             open_file_cache_min_uses 2;
             open_file_cache_errors off;
+
+            location ~* ^.+\.svgz$ {
+                gzip off;
+                add_header Content-Encoding gzip;
+            }
         }
 
         location ~* ^.+\.(?:css|js)$ {

--- a/drupal8.conf
+++ b/drupal8.conf
@@ -75,7 +75,7 @@ server {
             try_files $uri @drupal;
         }
 
-        location ~* ^.+\.(?:css|cur|js|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff|woff2|svg)$ {
+        location ~* ^.+\.(?:css|cur|js|jpe?g|gif|htc|ico|png|xml|otf|ttf|eot|woff2?|svgz?)$ {
             access_log off;
             expires 30d;
             tcp_nodelay off;
@@ -83,6 +83,11 @@ server {
             open_file_cache_valid 45s;
             open_file_cache_min_uses 2;
             open_file_cache_errors off;
+
+            location ~* ^.+\.svgz$ {
+                gzip off;
+                add_header Content-Encoding gzip;
+            }
         }
 
         location ~* ^.+\.(?:css|js)$ {
@@ -91,7 +96,7 @@ server {
             tcp_nodelay off;
             open_file_cache off;
         }
-        
+
         location ~* ^.+\.(?:pdf|pptx?)$ {
             expires 30d;
             tcp_nodelay off;


### PR DESCRIPTION
Hey,

Recently ran into an issue with an older project where we use already gzipped .svgz icon grids. 

With this small addition svgz can also be served correctly. The 'gzip off' is there because nginx was zipping the already zipped file again.

Gr, Niels
Unc Inc