### PR TITLE
support drupal sites with language prefixes

### DIFF
--- a/6/1.10/drupal.conf.tpl
+++ b/6/1.10/drupal.conf.tpl
@@ -16,7 +16,7 @@ server {
 
     location / {
 
-        location ^~ /system/files/ {
+        location ~* /system/files/ {
             fastcgi_param QUERY_STRING q=$uri&$args;
             fastcgi_param SCRIPT_NAME /index.php;
             fastcgi_param SCRIPT_FILENAME $document_root/index.php;
@@ -24,7 +24,7 @@ server {
             log_not_found off;
         }
 
-        location ^~ /sites/.*/files/private/ {
+        location ~* /sites/.*/files/private/ {
             internal;
         }
 

--- a/7/1.10/drupal.conf.tpl
+++ b/7/1.10/drupal.conf.tpl
@@ -16,7 +16,7 @@ server {
 
     location / {
 
-        location ^~ /system/files/ {
+        location ~* /system/files/ {
             fastcgi_param QUERY_STRING q=$uri&$args;
             fastcgi_param SCRIPT_NAME /index.php;
             fastcgi_param SCRIPT_FILENAME $document_root/index.php;
@@ -24,7 +24,7 @@ server {
             log_not_found off;
         }
 
-        location ^~ /sites/.*/files/private/ {
+        location ~* /sites/.*/files/private/ {
             internal;
         }
 

--- a/8/1.10/drupal.conf.tpl
+++ b/8/1.10/drupal.conf.tpl
@@ -16,7 +16,7 @@ server {
 
     location / {
 
-        location ^~ /system/files/ {
+        location ~* /system/files/ {
             fastcgi_param QUERY_STRING q=$uri&$args;
             fastcgi_param SCRIPT_NAME /index.php;
             fastcgi_param SCRIPT_FILENAME $document_root/index.php;
@@ -24,7 +24,7 @@ server {
             log_not_found off;
         }
 
-        location ^~ /sites/.*/files/private/ {
+        location ~* /sites/.*/files/private/ {
             internal;
         }
 


### PR DESCRIPTION
These changes should work with multilingual drupal sites that use private files. These typically have language prefixes before 'system/files'. e.g. example.com/jp/system/files/myfile.png