### PR TITLE
Added if statement to not override config if already it exists.

### DIFF
--- a/7/1.10/init/drupal-nginx.sh
+++ b/7/1.10/init/drupal-nginx.sh
@@ -8,4 +8,6 @@ fi
 
 chown www-data:www-data "${WODBY_DIR_FILES}"
 
-gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+if [ ! -e /etc/nginx/conf.d/drupal.conf ]; then
+    gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+fi

--- a/7/1.12/init/drupal-nginx.sh
+++ b/7/1.12/init/drupal-nginx.sh
@@ -8,4 +8,6 @@ fi
 
 chown www-data:www-data "${WODBY_DIR_FILES}"
 
-gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+if [ ! -e /etc/nginx/conf.d/drupal.conf ]; then
+    gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+fi

--- a/7/1.13/init/drupal-nginx.sh
+++ b/7/1.13/init/drupal-nginx.sh
@@ -8,4 +8,6 @@ fi
 
 chown www-data:www-data "${WODBY_DIR_FILES}"
 
-gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+if [ ! -e /etc/nginx/conf.d/drupal.conf ]; then
+    gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+fi

--- a/8/1.10/init/drupal-nginx.sh
+++ b/8/1.10/init/drupal-nginx.sh
@@ -8,4 +8,6 @@ fi
 
 chown www-data:www-data "${WODBY_DIR_FILES}"
 
-gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+if [ ! -e /etc/nginx/conf.d/drupal.conf ]; then
+    gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+fi

--- a/8/1.12/init/drupal-nginx.sh
+++ b/8/1.12/init/drupal-nginx.sh
@@ -8,4 +8,6 @@ fi
 
 chown www-data:www-data "${WODBY_DIR_FILES}"
 
-gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+if [ ! -e /etc/nginx/conf.d/drupal.conf ]; then
+    gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+fi

--- a/8/1.13/init/drupal-nginx.sh
+++ b/8/1.13/init/drupal-nginx.sh
@@ -8,4 +8,6 @@ fi
 
 chown www-data:www-data "${WODBY_DIR_FILES}"
 
-gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+if [ ! -e /etc/nginx/conf.d/drupal.conf ]; then
+    gotpl /etc/gotpl/drupal.conf.tpl > /etc/nginx/conf.d/drupal.conf
+fi


### PR DESCRIPTION
When adding custom config options to the Nginx config file it is always overridden when restarting the container. Adding a check to it if the config file is already in place will leave the changes intact. When the config file is not in place it will be placed like it used to.